### PR TITLE
Macos cxx changes

### DIFF
--- a/src/FbxNodeReader.cpp
+++ b/src/FbxNodeReader.cpp
@@ -1400,8 +1400,14 @@ namespace
 				VtValue( std::move( prop.values ) ),
 				{ helpers::getDisplayGroupMetadata( UsdFbxDisplayGroupTokens->user ),
 				  { SdfFieldKeys->Custom, VtValue( true ) } } );
-			usdProp.timeSamples
-				= std::vector< std::tuple< UsdTimeCode, VtValue > >( prop.timeSamples.begin(), prop.timeSamples.end() );
+			for( const auto& timeSample : prop.timeSamples )
+			{
+				UsdTimeCode t = timeSample.first;
+				for( const VtValue& value : timeSample.second )
+				{
+					usdProp.timeSamples.push_back(std::make_pair(t, value));
+				}
+			}
 
 			// add special property to indicate this custom property's owner (joint
 			// path)

--- a/src/FbxNodeReader.cpp
+++ b/src/FbxNodeReader.cpp
@@ -1405,7 +1405,7 @@ namespace
 				UsdTimeCode t = timeSample.first;
 				for( const VtValue& value : timeSample.second )
 				{
-					usdProp.timeSamples.push_back(std::make_pair(t, value));
+					usdProp.timeSamples.emplace_back(t, value);
 				}
 			}
 


### PR DESCRIPTION
At least with the clang shipped with macos 12.5, `prop.timeSamples` and `usdProp.timeSamples` are too different to easily copy from one to the other: prop.timeSamples is a map from time to a list of values, whereas `usdProp.timeSamples` is a flattened list of pairs of time and values. I didn't know any compiler allowed implicit flattening like that but clang doesn't.